### PR TITLE
Speed up defer when "Group GOAL" contains redices

### DIFF
--- a/src/Procrastination.v
+++ b/src/Procrastination.v
@@ -635,7 +635,7 @@ Abort.
    proof.
 *)
 Ltac defer_aux tm ty :=
-  let ty' := (eval simpl in ty) in
+  let ty' := (eval hnf in ty) in
   lazymatch ty' with
   | and ?x ?y => defer_aux (@proj2 x y tm) y
   | _ => eapply (proj1 tm)


### PR DESCRIPTION
e.g. with the following deferred goal, the call of simpl instead of hnf forces the whole evaluation of the arithmetic involved, although you only want to see the head constant:
` Group
      ((forall n m : nat,
        (Z.of_nat
           (1 + (25 + 12 * S n) +
            (1 + (25 + 12 * S m) +
             (1 + (8 + 4 * S (n - m - 1)) + (1 + (8 + 4 * S (m - n - 1)) + 0) +
               (1 + (8 + 4 * S (n - m - 1)) + (1 + (8 + 4 * S (m - m - 1)) + 0))))) <= T (Z.of_nat m, Z.of_nat n))%Z) /\ 
       ?B)`